### PR TITLE
Add provider interface and GitHub implementation

### DIFF
--- a/src/providers/IProvider.ts
+++ b/src/providers/IProvider.ts
@@ -1,0 +1,30 @@
+export interface IProvider {
+  /**
+   * Return the diff between two git refs. Optionally limit to a single file path.
+   */
+  getDiff(base: string, head: string, filePath?: string): Promise<string>;
+
+  /**
+   * Create a progress comment and return the new comment id.
+   */
+  createProgressComment(body: string): Promise<number>;
+
+  /**
+   * Update an existing comment.
+   */
+  updateComment(commentId: number, body: string): Promise<void>;
+
+  /**
+   * Add an inline comment on a specific file and line. Returns the new comment id.
+   */
+  addInlineComment(
+    filePath: string,
+    line: number,
+    body: string,
+  ): Promise<number>;
+
+  /**
+   * Commit staged changes as a fixup commit and push to the remote. Returns the commit SHA.
+   */
+  pushFixupCommit(message: string): Promise<string>;
+}

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,0 +1,77 @@
+import { $ } from "bun";
+import type { Octokits } from "../github/api/client";
+import type { ParsedGitHubContext } from "../github/context";
+import { IProvider } from "./IProvider";
+
+export class GitHubProvider implements IProvider {
+  constructor(
+    private octokits: Octokits,
+    private context: ParsedGitHubContext,
+  ) {}
+
+  async getDiff(
+    base: string,
+    head: string,
+    filePath?: string,
+  ): Promise<string> {
+    const args = [base, head];
+    if (filePath) {
+      args.push("--", filePath);
+    }
+    const { stdout } = await $`git diff ${args}`.quiet();
+    return stdout.toString();
+  }
+
+  async createProgressComment(body: string): Promise<number> {
+    const { owner, repo } = this.context.repository;
+    const res = await this.octokits.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: this.context.entityNumber,
+      body,
+    });
+    return res.data.id;
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    const { owner, repo } = this.context.repository;
+    await this.octokits.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body,
+    });
+  }
+
+  async addInlineComment(
+    filePath: string,
+    line: number,
+    body: string,
+  ): Promise<number> {
+    const { owner, repo } = this.context.repository;
+    const pr = await this.octokits.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: this.context.entityNumber,
+    });
+    const res = await this.octokits.rest.pulls.createReviewComment({
+      owner,
+      repo,
+      pull_number: this.context.entityNumber,
+      commit_id: pr.data.head.sha,
+      body,
+      path: filePath,
+      line,
+    });
+    return res.data.id;
+  }
+
+  async pushFixupCommit(message: string): Promise<string> {
+    await $`git add -A`.quiet();
+    await $`git commit -m ${message}`.quiet();
+    const { stdout } = await $`git rev-parse HEAD`.quiet();
+    const sha = stdout.toString().trim();
+    await $`git push`.quiet();
+    return sha;
+  }
+}


### PR DESCRIPTION
## Summary
- add `IProvider` interface to describe repo provider operations
- implement `GitHubProvider` with existing Octokit helpers

## Testing
- `bun test`
- `bun run format`
