### PR TITLE
feat: add GitLab provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@octokit/graphql": "^8.2.2",
     "@octokit/rest": "^21.1.1",
     "@octokit/webhooks-types": "^7.6.1",
+    "@gitbeaker/rest": "^39.5.0",
     "node-fetch": "^3.3.2",
     "zod": "^3.24.4"
   },

--- a/src/providers/gitlab/api/client.ts
+++ b/src/providers/gitlab/api/client.ts
@@ -1,0 +1,8 @@
+import { Gitlab } from "@gitbeaker/rest";
+import { GITLAB_API_URL } from "./config";
+
+export type GitLabClient = InstanceType<typeof Gitlab>;
+
+export function createGitLabClient(token: string): GitLabClient {
+  return new Gitlab({ host: GITLAB_API_URL, token });
+}

--- a/src/providers/gitlab/api/config.ts
+++ b/src/providers/gitlab/api/config.ts
@@ -1,0 +1,4 @@
+export const GITLAB_API_URL =
+  process.env.GITLAB_API_URL || "https://gitlab.com/api/v4";
+export const GITLAB_SERVER_URL =
+  process.env.GITLAB_SERVER_URL || "https://gitlab.com";

--- a/src/providers/gitlab/index.ts
+++ b/src/providers/gitlab/index.ts
@@ -1,0 +1,2 @@
+export * from "./api/client";
+export * from "./provider";

--- a/src/providers/gitlab/provider.ts
+++ b/src/providers/gitlab/provider.ts
@@ -1,0 +1,77 @@
+import { $ } from "bun";
+import type { GitLabClient } from "./api/client";
+import { IProvider } from "../IProvider";
+
+export class GitLabProvider implements IProvider {
+  constructor(
+    private client: GitLabClient,
+    private projectId: string | number,
+    private mergeRequestIid: number,
+    private headSha: string,
+  ) {}
+
+  async getDiff(): Promise<string> {
+    const res: any = await this.client.MergeRequests.changes(
+      this.projectId,
+      this.mergeRequestIid,
+    );
+    const diffs = res.changes.map((c: any) => c.diff).join("\n");
+    return diffs;
+  }
+
+  async createProgressComment(body: string): Promise<number> {
+    const discussion: any = await this.client.MergeRequestDiscussions.create(
+      this.projectId,
+      this.mergeRequestIid,
+      body,
+    );
+    const note = discussion.notes[0];
+    return note.id;
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    const note: any = await this.client.MergeRequestNotes.show(
+      this.projectId,
+      this.mergeRequestIid,
+      commentId,
+    );
+    await this.client.MergeRequestDiscussions.editNote(
+      this.projectId,
+      this.mergeRequestIid,
+      note.discussion_id,
+      commentId,
+      body,
+    );
+  }
+
+  async addInlineComment(
+    filePath: string,
+    line: number,
+    body: string,
+  ): Promise<number> {
+    const discussion: any = await this.client.MergeRequestDiscussions.create(
+      this.projectId,
+      this.mergeRequestIid,
+      body,
+      {
+        position: {
+          position_type: "text",
+          new_path: filePath,
+          new_line: line,
+          head_sha: this.headSha,
+        },
+      },
+    );
+    const note = discussion.notes[0];
+    return note.id;
+  }
+
+  async pushFixupCommit(message: string): Promise<string> {
+    await $`git add -A`.quiet();
+    await $`git commit -m ${message}`.quiet();
+    const { stdout } = await $`git rev-parse HEAD`.quiet();
+    const sha = stdout.toString().trim();
+    await $`git push`.quiet();
+    return sha;
+  }
+}


### PR DESCRIPTION
## Summary
- add GitLab API client and config
- implement `GitLabProvider` using @gitbeaker/rest
- expose GitLab provider modules
- include `@gitbeaker/rest` dependency

## Testing
- `bun run format`
- `bun test`