### PR TITLE
Add provider detection CLI and provider usage

### DIFF
--- a/bin/claude-code-action.ts
+++ b/bin/claude-code-action.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env bun
+import { getProvider } from "../src/providers/provider-factory";
+import { run as prepare } from "../src/entrypoints/prepare";
+import { run as updateCommentLink } from "../src/entrypoints/update-comment-link";
+
+function parseArgs(args: string[]) {
+  const opts: any = { _: [] };
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    switch (arg) {
+      case "--provider":
+        opts.provider = args[++i];
+        break;
+      case "--project-id":
+        opts.projectId = args[++i];
+        break;
+      case "--mr-iid":
+        opts.mrIid = args[++i];
+        break;
+      case "--gitlab-host":
+        opts.gitlabHost = args[++i];
+        break;
+      default:
+        opts._.push(arg);
+        break;
+    }
+    i++;
+  }
+  return opts;
+}
+
+const parsed = parseArgs(Bun.argv.slice(2));
+const command = parsed._.shift() ?? "prepare";
+const { provider, context, octokits } = getProvider(parsed);
+
+switch (command) {
+  case "prepare":
+    await prepare(provider as any, context as any, octokits as any);
+    break;
+  case "update-comment-link":
+    await updateCommentLink(provider as any, context as any, octokits as any);
+    break;
+  default:
+    console.error(`Unknown command: ${command}`);
+    process.exit(1);
+}

--- a/src/gitlab/context.ts
+++ b/src/gitlab/context.ts
@@ -1,0 +1,21 @@
+export type ParsedGitLabContext = {
+  projectId: string;
+  mrIid?: string;
+  host: string;
+};
+
+export function parseGitLabContext(
+  opts: {
+    projectId?: string;
+    mrIid?: string;
+    host?: string;
+  } = {},
+): ParsedGitLabContext {
+  const projectId = opts.projectId ?? process.env.CI_PROJECT_ID;
+  const mrIid = opts.mrIid ?? process.env.CI_MERGE_REQUEST_IID;
+  const host = opts.host ?? process.env.CI_SERVER_URL ?? "https://gitlab.com";
+  if (!projectId) {
+    throw new Error("GitLab project ID is required");
+  }
+  return { projectId, mrIid, host };
+}

--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -1,0 +1,97 @@
+import { $ } from "bun";
+import fetch from "node-fetch";
+import { IProvider } from "./IProvider";
+import type { ParsedGitLabContext } from "../gitlab/context";
+
+export class GitLabProvider implements IProvider {
+  constructor(
+    private token: string,
+    private context: ParsedGitLabContext,
+  ) {}
+
+  private async request(path: string, options: fetch.RequestInit = {}) {
+    const url = `${this.context.host}/api/v4${path}`;
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        "PRIVATE-TOKEN": this.token,
+        "Content-Type": "application/json",
+        ...(options.headers ?? {}),
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitLab API error ${res.status}: ${text}`);
+    }
+    return res.json() as Promise<any>;
+  }
+
+  async getDiff(
+    base: string,
+    head: string,
+    filePath?: string,
+  ): Promise<string> {
+    const args = [base, head];
+    if (filePath) args.push("--", filePath);
+    const { stdout } = await $`git diff ${args}`.quiet();
+    return stdout.toString();
+  }
+
+  async createProgressComment(body: string): Promise<number> {
+    if (!this.context.mrIid) throw new Error("mrIid required");
+    const data = await this.request(
+      `/projects/${encodeURIComponent(this.context.projectId)}/merge_requests/${this.context.mrIid}/notes`,
+      {
+        method: "POST",
+        body: JSON.stringify({ body }),
+      },
+    );
+    return data.id as number;
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    if (!this.context.mrIid) throw new Error("mrIid required");
+    await this.request(
+      `/projects/${encodeURIComponent(this.context.projectId)}/merge_requests/${this.context.mrIid}/notes/${commentId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ body }),
+      },
+    );
+  }
+
+  async addInlineComment(
+    filePath: string,
+    line: number,
+    body: string,
+  ): Promise<number> {
+    if (!this.context.mrIid) throw new Error("mrIid required");
+    const { stdout } = await $`git rev-parse HEAD`.quiet();
+    const headSha = stdout.toString().trim();
+    const data = await this.request(
+      `/projects/${encodeURIComponent(this.context.projectId)}/merge_requests/${this.context.mrIid}/discussions`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          body,
+          position: {
+            position_type: "text",
+            new_path: filePath,
+            new_line: line,
+            head_sha: headSha,
+          },
+        }),
+      },
+    );
+    return data.notes?.[0]?.id ?? data.id;
+  }
+
+  async pushFixupCommit(message: string): Promise<string> {
+    await $`git add -A`.quiet();
+    await $`git commit -m ${message}`.quiet();
+    const { stdout } = await $`git rev-parse HEAD`.quiet();
+    const sha = stdout.toString().trim();
+    await $`git push`.quiet();
+    return sha;
+  }
+}

--- a/src/providers/provider-factory.ts
+++ b/src/providers/provider-factory.ts
@@ -1,0 +1,48 @@
+import { createOctokit, type Octokits } from "../github/api/client";
+import {
+  parseGitHubContext,
+  type ParsedGitHubContext,
+} from "../github/context";
+import {
+  parseGitLabContext,
+  type ParsedGitLabContext,
+} from "../gitlab/context";
+import { GitHubProvider } from "./github";
+import { GitLabProvider } from "./gitlab";
+import type { IProvider } from "./IProvider";
+
+export type ProviderType = "github" | "gitlab";
+
+export type ProviderResult = {
+  provider: IProvider;
+  context: ParsedGitHubContext | ParsedGitLabContext;
+  octokits?: Octokits;
+};
+
+export function getProvider(
+  opts: {
+    provider?: ProviderType;
+    projectId?: string;
+    mrIid?: string;
+    gitlabHost?: string;
+  } = {},
+): ProviderResult {
+  const providerName = (opts.provider ??
+    process.env.CI_PLATFORM ??
+    "github") as ProviderType;
+
+  if (providerName === "gitlab") {
+    const token = process.env.GITLAB_TOKEN!;
+    const context = parseGitLabContext({
+      projectId: opts.projectId,
+      mrIid: opts.mrIid,
+      host: opts.gitlabHost,
+    });
+    return { provider: new GitLabProvider(token, context), context };
+  }
+
+  const token = process.env.GITHUB_TOKEN!;
+  const octokits = createOctokit(token);
+  const context = parseGitHubContext();
+  return { provider: new GitHubProvider(octokits, context), context, octokits };
+}


### PR DESCRIPTION
## Summary
- add CLI tool to select provider and run entrypoints
- support GitLab provider and context parsing
- provide provider factory to create correct provider
- update prepare and update-comment-link entrypoints to use provider abstraction

## Testing
- `bun run format`
- `bun run test`