### PR TITLE
Add GitLab provider tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "lint-fix": "prettier --write .",
     "install-hooks": "bun run scripts/install-hooks.sh",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
@@ -23,6 +24,7 @@
     "@types/bun": "1.2.11",
     "@types/node": "^20.0.0",
     "@types/node-fetch": "^2.6.12",
+    "nock": "^14.0.0",
     "prettier": "3.5.3",
     "typescript": "^5.8.3"
   }

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import type { Octokits } from "../github/api/client";
 import type { ParsedGitHubContext } from "../github/context";
-import { IProvider } from "./IProvider";
+import type { IProvider } from "./IProvider";
 
 export class GitHubProvider implements IProvider {
   constructor(

--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -1,0 +1,87 @@
+import { $ } from "bun";
+import fetch from "node-fetch";
+import type { IProvider } from "./IProvider";
+
+export interface GitLabContext {
+  projectId: string;
+  mergeRequestIid: number;
+}
+
+export class GitLabProvider implements IProvider {
+  constructor(
+    private token: string,
+    private context: GitLabContext,
+    private baseUrl = "https://gitlab.com/api/v4",
+  ) {}
+
+  async getDiff(
+    base: string,
+    head: string,
+    filePath?: string,
+  ): Promise<string> {
+    const args = [base, head];
+    if (filePath) args.push("--", filePath);
+    const { stdout } = await $`git diff ${args}`.quiet();
+    return stdout.toString();
+  }
+
+  async createProgressComment(body: string): Promise<number> {
+    const url = `${this.baseUrl}/projects/${encodeURIComponent(this.context.projectId)}/merge_requests/${this.context.mergeRequestIid}/notes`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "PRIVATE-TOKEN": this.token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+    });
+    const data = (await res.json()) as { id: number };
+    return data.id;
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    const url = `${this.baseUrl}/projects/${encodeURIComponent(this.context.projectId)}/merge_requests/${this.context.mergeRequestIid}/notes/${commentId}`;
+    await fetch(url, {
+      method: "PUT",
+      headers: {
+        "PRIVATE-TOKEN": this.token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async addInlineComment(
+    filePath: string,
+    line: number,
+    body: string,
+  ): Promise<number> {
+    const url = `${this.baseUrl}/projects/${encodeURIComponent(this.context.projectId)}/merge_requests/${this.context.mergeRequestIid}/discussions`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "PRIVATE-TOKEN": this.token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        body,
+        position: {
+          position_type: "text",
+          new_path: filePath,
+          new_line: line,
+        },
+      }),
+    });
+    const data = (await res.json()) as { notes?: { id: number }[] };
+    return data.notes?.[0]?.id ?? 0;
+  }
+
+  async pushFixupCommit(message: string): Promise<string> {
+    await $`git add -A`.quiet();
+    await $`git commit -m ${message}`.quiet();
+    const { stdout } = await $`git rev-parse HEAD`.quiet();
+    const sha = stdout.toString().trim();
+    await $`git push`.quiet();
+    return sha;
+  }
+}

--- a/test/__snapshots__/provider-gitlab.spec.ts.snap
+++ b/test/__snapshots__/provider-gitlab.spec.ts.snap
@@ -1,0 +1,9 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GitLabProvider retrieves diff between refs 1`] = `""`;
+
+exports[`GitLabProvider creates progress comment 1`] = `
+{
+  "body": "Work started",
+}
+`;

--- a/test/provider-gitlab.spec.ts
+++ b/test/provider-gitlab.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import * as nodeFetch from "node-fetch";
+import { GitLabProvider } from "../src/providers/gitlab";
+
+const context = { projectId: "123", mergeRequestIid: 10 };
+
+describe("GitLabProvider", () => {
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(nodeFetch, "default").mockResolvedValue({
+      json: async () => ({ id: 99, notes: [{ id: 88 }] }),
+    } as any);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("creates progress comment", async () => {
+    const provider = new GitLabProvider("TOKEN", context);
+    const id = await provider.createProgressComment("Work started");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/projects/123/merge_requests/10/notes",
+      {
+        method: "POST",
+        headers: {
+          "PRIVATE-TOKEN": "TOKEN",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ body: "Work started" }),
+      },
+    );
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as any).body);
+    expect(body).toMatchSnapshot();
+    expect(id).toBe(99);
+  });
+
+  it("retrieves diff between refs", async () => {
+    const provider = new GitLabProvider("TOKEN", context);
+    const diff = await provider.getDiff("HEAD", "HEAD");
+    expect(diff).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- add GitLabProvider implementation
- test GitLabProvider with mocked REST calls
- snapshot comment body and diff output
- expose `lint-fix` script and add nock dev dep

## Testing
- `npm run lint-fix`
- `npm test`
- `npm run typecheck`
