### PR TITLE
Add GitLab trigger detection

### DIFF
--- a/src/gitlab/validation/trigger.ts
+++ b/src/gitlab/validation/trigger.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+
+import * as core from "@actions/core";
+import { escapeRegExp } from "../../github/validation/trigger";
+
+export type GitLabMergeRequestEvent = {
+  object_kind: "merge_request";
+  object_attributes: {
+    title?: string;
+    description?: string;
+  };
+};
+
+export type GitLabNoteEvent = {
+  object_kind: "note";
+  object_attributes: {
+    note: string;
+    noteable_type: string;
+  };
+};
+
+export type ParsedGitLabWebhookContext = {
+  payload: GitLabMergeRequestEvent | GitLabNoteEvent;
+  inputs: {
+    triggerPhrase: string;
+    directPrompt: string;
+  };
+};
+
+export function checkContainsTrigger(
+  context: ParsedGitLabWebhookContext,
+): boolean {
+  const {
+    inputs: { triggerPhrase, directPrompt },
+    payload,
+  } = context;
+
+  if (directPrompt) {
+    console.log(`Direct prompt provided, triggering action`);
+    return true;
+  }
+
+  const regex = new RegExp(
+    `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+  );
+
+  if (payload.object_kind === "merge_request") {
+    const desc = payload.object_attributes.description || "";
+    const title = payload.object_attributes.title || "";
+    if (regex.test(desc)) {
+      console.log(
+        `Merge request description contains exact trigger phrase '${triggerPhrase}'`,
+      );
+      return true;
+    }
+    if (regex.test(title)) {
+      console.log(
+        `Merge request title contains exact trigger phrase '${triggerPhrase}'`,
+      );
+      return true;
+    }
+  }
+
+  if (payload.object_kind === "note") {
+    const note = payload.object_attributes.note || "";
+    if (regex.test(note)) {
+      console.log(`Comment contains exact trigger phrase '${triggerPhrase}'`);
+      return true;
+    }
+  }
+
+  console.log(`No trigger was met for ${triggerPhrase}`);
+  return false;
+}
+
+export async function checkTriggerAction(context: ParsedGitLabWebhookContext) {
+  const containsTrigger = checkContainsTrigger(context);
+  core.setOutput("contains_trigger", containsTrigger.toString());
+  return containsTrigger;
+}

--- a/test/gitlab-trigger-validation.test.ts
+++ b/test/gitlab-trigger-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "bun:test";
+import { checkContainsTrigger } from "../src/gitlab/validation/trigger";
+
+const baseInputs = { triggerPhrase: "@claude", directPrompt: "" };
+
+describe("GitLab trigger detection", () => {
+  it("detects trigger in merge request description", () => {
+    const context = {
+      inputs: baseInputs,
+      payload: {
+        object_kind: "merge_request",
+        object_attributes: {
+          description: "Please review @claude.",
+          title: "Add feature",
+        },
+      },
+    } as const;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("detects trigger in merge request title", () => {
+    const context = {
+      inputs: baseInputs,
+      payload: {
+        object_kind: "merge_request",
+        object_attributes: {
+          description: "No trigger here",
+          title: "@claude please review",
+        },
+      },
+    } as const;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("detects trigger in note comment", () => {
+    const context = {
+      inputs: baseInputs,
+      payload: {
+        object_kind: "note",
+        object_attributes: {
+          note: "Hey @claude, take a look",
+          noteable_type: "MergeRequest",
+        },
+      },
+    } as const;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("returns false when trigger not present", () => {
+    const context = {
+      inputs: baseInputs,
+      payload: {
+        object_kind: "note",
+        object_attributes: {
+          note: "Just a comment",
+          noteable_type: "MergeRequest",
+        },
+      },
+    } as const;
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- implement trigger detection for GitLab webhook payloads
- add tests for GitLab merge request and note events

## Testing
- `bun test`