### PR TITLE
Fix typecheck errors

### DIFF
--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -7,7 +7,6 @@ import {
   type CommentUpdateInput,
 } from "../github/operations/comment-logic";
 import {
-  parseGitHubContext,
   isPullRequestReviewCommentEvent,
   type ParsedGitHubContext,
 } from "../github/context";

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import type { Octokits } from "../github/api/client";
 import type { ParsedGitHubContext } from "../github/context";
-import { IProvider } from "./IProvider";
+import type { IProvider } from "./IProvider";
 
 export class GitHubProvider implements IProvider {
   constructor(

--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import fetch from "node-fetch";
-import { IProvider } from "./IProvider";
+import fetch, { type RequestInit } from "node-fetch";
+import type { IProvider } from "./IProvider";
 import type { ParsedGitLabContext } from "../gitlab/context";
 
 export class GitLabProvider implements IProvider {
@@ -9,7 +9,7 @@ export class GitLabProvider implements IProvider {
     private context: ParsedGitLabContext,
   ) {}
 
-  private async request(path: string, options: fetch.RequestInit = {}) {
+  private async request(path: string, options: RequestInit = {}) {
     const url = `${this.context.host}/api/v4${path}`;
     const res = await fetch(url, {
       ...options,

--- a/test/gitlab-context.test.ts
+++ b/test/gitlab-context.test.ts
@@ -37,8 +37,6 @@ describe("parseGitLabContext", () => {
   });
 
   it("throws when CI_PROJECT_ID is missing", () => {
-    expect(() => parseGitLabContext()).toThrow(
-      "GitLab project ID is required",
-    );
+    expect(() => parseGitLabContext()).toThrow("GitLab project ID is required");
   });
 });

--- a/test/gitlab-provider.test.ts
+++ b/test/gitlab-provider.test.ts
@@ -19,10 +19,7 @@ function mockShell(outputs: string[] = []) {
   const commands: string[] = [];
   let index = 0;
   const original = bun.$;
-  const mockFn = (
-    strings: TemplateStringsArray,
-    ...expressions: any[]
-  ) => {
+  const mockFn = (strings: TemplateStringsArray, ...expressions: any[]) => {
     const cmd = strings.reduce((acc, str, i) => {
       const expr = i < expressions.length ? expressions[i] : "";
       const val = Array.isArray(expr) ? expr.join(" ") : String(expr);
@@ -33,7 +30,11 @@ function mockShell(outputs: string[] = []) {
     return { quiet: async () => ({ stdout: Buffer.from(stdout) }) } as any;
   };
   bun.$ = mockFn as any;
-  shellSpy = { restore: () => { bun.$ = original; } } as any;
+  shellSpy = {
+    restore: () => {
+      bun.$ = original;
+    },
+  } as any;
   return commands;
 }
 
@@ -49,7 +50,9 @@ describe("GitLabProvider", () => {
 
   test("createProgressComment uses correct endpoint", async () => {
     mockShell();
-    ({ GitLabProvider } = await import(`../src/providers/gitlab?${Math.random()}`));
+    ({ GitLabProvider } = await import(
+      `../src/providers/gitlab?${Math.random()}`
+    ));
     const provider = new GitLabProvider(token, context);
     fetchSpy = jest.fn().mockResolvedValue({ id: 42 });
     (provider as any).request = async (path: string, options: any) => {
@@ -72,7 +75,9 @@ describe("GitLabProvider", () => {
 
   test("updateComment uses PUT with correct body", async () => {
     mockShell();
-    ({ GitLabProvider } = await import(`../src/providers/gitlab?${Math.random()}`));
+    ({ GitLabProvider } = await import(
+      `../src/providers/gitlab?${Math.random()}`
+    ));
     const provider = new GitLabProvider(token, context);
     fetchSpy = jest.fn().mockResolvedValue({});
     (provider as any).request = async (path: string, options: any) => {
@@ -94,7 +99,9 @@ describe("GitLabProvider", () => {
 
   test("addInlineComment posts with position info", async () => {
     const commands = mockShell(["abc123\n"]);
-    ({ GitLabProvider } = await import(`../src/providers/gitlab?${Math.random()}`));
+    ({ GitLabProvider } = await import(
+      `../src/providers/gitlab?${Math.random()}`
+    ));
     const provider = new GitLabProvider(token, context);
     fetchSpy = jest.fn().mockResolvedValue({ notes: [{ id: 7 }] });
     (provider as any).request = async (path: string, options: any) => {
@@ -126,7 +133,9 @@ describe("GitLabProvider", () => {
 
   test("pushFixupCommit runs git commands", async () => {
     const commands = mockShell(["", "", "abc123\n", ""]);
-    ({ GitLabProvider } = await import(`../src/providers/gitlab?${Math.random()}`));
+    ({ GitLabProvider } = await import(
+      `../src/providers/gitlab?${Math.random()}`
+    ));
     const provider = new GitLabProvider(token, context);
     const sha = await provider.pushFixupCommit("fix msg");
 
@@ -141,7 +150,9 @@ describe("GitLabProvider", () => {
 
   test("getDiff runs git diff", async () => {
     let commands = mockShell(["diff\n"]);
-    ({ GitLabProvider } = await import(`../src/providers/gitlab?${Math.random()}`));
+    ({ GitLabProvider } = await import(
+      `../src/providers/gitlab?${Math.random()}`
+    ));
     let provider = new GitLabProvider(token, context);
     const diff = await provider.getDiff("base", "head");
     expect(diff).toBe("diff\n");
@@ -149,7 +160,9 @@ describe("GitLabProvider", () => {
 
     restoreSpies();
     commands = mockShell(["diff2\n"]);
-    ({ GitLabProvider } = await import(`../src/providers/gitlab?${Math.random()}`));
+    ({ GitLabProvider } = await import(
+      `../src/providers/gitlab?${Math.random()}`
+    ));
     provider = new GitLabProvider(token, context);
     const diff2 = await provider.getDiff("base", "head", "file.txt");
     expect(diff2).toBe("diff2\n");

--- a/test/gitlab-token.test.ts
+++ b/test/gitlab-token.test.ts
@@ -23,7 +23,7 @@ describe("setupGitLabToken", () => {
     originalEnv = { ...process.env };
     originalArgv = [...process.argv];
     process.env = {};
-    process.argv = [originalArgv[0], originalArgv[1]];
+    process.argv = [originalArgv[0]!, originalArgv[1]!];
     setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
     consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
   });


### PR DESCRIPTION
## Summary
- fix unused parseGitHubContext import
- use type-only imports for IProvider
- import RequestInit from node-fetch
- fix argv handling in GitLab token tests
- run Prettier on GitLab tests

## Testing
- `npm run typecheck`
- `npm test`
- `npm run format:check`
