### PR TITLE
Add GitLab branch setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Follow these steps to run the action in GitLab CI/CD:
    npx claude-code-action --provider gitlab --project-id $CI_PROJECT_ID \
    --mr-iid $CI_MERGE_REQUEST_IID --gitlab-host $CI_SERVER_URL
    ```
+4. **Branch handling**
+   - Open merge requests are checked out directly.
+   - Closed or merged requests create a new `claude/mr-<iid>-TIMESTAMP` branch.
 
 See [`examples/gitlab-ci.yml`](./examples/gitlab-ci.yml) for a complete
 pipeline example.

--- a/src/gitlab/operations/branch.ts
+++ b/src/gitlab/operations/branch.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+import * as core from "@actions/core";
+import type { ParsedGitLabContext } from "../context";
+
+export type BranchInfo = {
+  defaultBranch: string;
+  claudeBranch?: string;
+  currentBranch: string;
+};
+
+export async function setupBranch(
+  token: string,
+  context: ParsedGitLabContext,
+): Promise<BranchInfo> {
+  const { projectId, mrIid, host } = context;
+
+  const headers = {
+    "PRIVATE-TOKEN": token,
+    "Content-Type": "application/json",
+  };
+
+  const projectRes = await fetch(
+    `${host}/api/v4/projects/${encodeURIComponent(projectId)}`,
+    { headers },
+  );
+  if (!projectRes.ok) {
+    throw new Error(`Failed to fetch project: ${await projectRes.text()}`);
+  }
+  const projectData = (await projectRes.json()) as { default_branch: string };
+  const defaultBranch = projectData.default_branch;
+
+  if (mrIid) {
+    const mrRes = await fetch(
+      `${host}/api/v4/projects/${encodeURIComponent(projectId)}/merge_requests/${mrIid}`,
+      { headers },
+    );
+    if (!mrRes.ok) {
+      throw new Error(`Failed to fetch MR: ${await mrRes.text()}`);
+    }
+    const mrData = (await mrRes.json()) as {
+      state: string;
+      source_branch: string;
+    };
+
+    if (mrData.state === "opened") {
+      const branchName = mrData.source_branch;
+      await $`git fetch origin ${branchName}`;
+      await $`git checkout ${branchName}`;
+      return { defaultBranch, currentBranch: branchName };
+    }
+    console.log(
+      `MR !${mrIid} is ${mrData.state}, creating new branch from default...`,
+    );
+  }
+
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:-]/g, "")
+    .replace(/\.\d{3}Z/, "")
+    .split("T")
+    .join("_");
+  const newBranch = `claude/mr-${mrIid ?? ""}-${timestamp}`;
+
+  const createRes = await fetch(
+    `${host}/api/v4/projects/${encodeURIComponent(projectId)}/repository/branches?branch=${encodeURIComponent(newBranch)}&ref=${encodeURIComponent(defaultBranch)}`,
+    { method: "POST", headers },
+  );
+  if (!createRes.ok) {
+    throw new Error(`Failed to create branch: ${await createRes.text()}`);
+  }
+
+  await $`git fetch origin ${newBranch}`;
+  await $`git checkout ${newBranch}`;
+
+  core.setOutput("CLAUDE_BRANCH", newBranch);
+  core.setOutput("DEFAULT_BRANCH", defaultBranch);
+
+  return { defaultBranch, claudeBranch: newBranch, currentBranch: newBranch };
+}

--- a/test/gitlab-branch.test.ts
+++ b/test/gitlab-branch.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, afterEach, jest } from "bun:test";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const bun = require("bun");
+
+import type { ParsedGitLabContext } from "../src/gitlab/context";
+
+let fetchSpy: any;
+let shellSpy: any;
+
+function mockShell(outputs: string[] = []) {
+  const commands: string[] = [];
+  let index = 0;
+  const original = bun.$;
+  const mockFn = (strings: TemplateStringsArray, ...expressions: any[]) => {
+    const cmd = strings.reduce((acc, str, i) => {
+      const expr = i < expressions.length ? expressions[i] : "";
+      const val = Array.isArray(expr) ? expr.join(" ") : String(expr);
+      return acc + str + val;
+    }, "");
+    commands.push(cmd.trim());
+    const stdout = outputs[index++] ?? "";
+    return { quiet: async () => ({ stdout: Buffer.from(stdout) }) } as any;
+  };
+  bun.$ = mockFn as any;
+  shellSpy = {
+    restore: () => {
+      bun.$ = original;
+    },
+  } as any;
+  return commands;
+}
+
+function restoreSpies() {
+  if (fetchSpy) fetchSpy.mockRestore();
+  if (shellSpy) shellSpy.restore();
+}
+
+describe("gitlab setupBranch", () => {
+  const token = "tok";
+  const context: ParsedGitLabContext = {
+    projectId: "1",
+    mrIid: "10",
+    host: "https://gitlab.com",
+  };
+
+  afterEach(() => {
+    restoreSpies();
+  });
+
+  test("checks out existing MR branch when open", async () => {
+    const commands = mockShell(["", ""]);
+    fetchSpy = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ default_branch: "main" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "opened", source_branch: "feat" }),
+      });
+    // @ts-expect-error override
+    global.fetch = fetchSpy;
+    const { setupBranch } = await import(
+      `../src/gitlab/operations/branch?${Math.random()}`
+    );
+
+    const info = await setupBranch(token, context);
+
+    expect(info).toEqual({ defaultBranch: "main", currentBranch: "feat" });
+    expect(commands).toEqual(["git fetch origin feat", "git checkout feat"]);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/projects/1",
+      {
+        headers: { "PRIVATE-TOKEN": token, "Content-Type": "application/json" },
+      },
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/projects/1/merge_requests/10",
+      {
+        headers: { "PRIVATE-TOKEN": token, "Content-Type": "application/json" },
+      },
+    );
+  });
+
+  test("creates new branch when MR closed", async () => {
+    const commands = mockShell(["", ""]);
+    fetchSpy = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ default_branch: "main" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "merged", source_branch: "feat" }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+    // @ts-expect-error override
+    global.fetch = fetchSpy;
+    const { setupBranch } = await import(
+      `../src/gitlab/operations/branch?${Math.random()}`
+    );
+
+    const info = await setupBranch(token, context);
+
+    expect(info.currentBranch).toMatch(/^claude\/mr-10-/);
+    expect(info.claudeBranch).toBe(info.currentBranch);
+    expect(info.defaultBranch).toBe("main");
+    expect(commands).toEqual([
+      `git fetch origin ${info.currentBranch}`,
+      `git checkout ${info.currentBranch}`,
+    ]);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/projects/1/repository/branches?branch=" +
+        encodeURIComponent(info.currentBranch) +
+        "&ref=main",
+      {
+        method: "POST",
+        headers: { "PRIVATE-TOKEN": token, "Content-Type": "application/json" },
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement `src/gitlab/operations/branch.ts` for creating/checking out branches via GitLab API
- document new GitLab branch workflow
- add tests for GitLab branch operations

## Testing
- `bun run format:check`
- `bun test`