### PR TITLE
Fix pre-push newline

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -44,3 +44,4 @@ else
 fi
 
 exit 0
+


### PR DESCRIPTION
## Summary
- add a newline after the final `exit 0` command in `scripts/pre-push`

## Testing
- `git status --short`